### PR TITLE
Implementing since and until

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ target/
 /pysparkling/tests/20news-19997.tar.gz
 
 /scripts_private/
+.scannerwork/

--- a/pysparkling/__init__.py
+++ b/pysparkling/__init__.py
@@ -3,6 +3,7 @@
 
 from . import exceptions, fileio, streaming
 from .__version__ import __version__
+from ._config import config
 from .accumulators import Accumulator, AccumulatorParam
 from .broadcast import Broadcast
 from .cache_manager import CacheManager, TimedCacheManager
@@ -12,6 +13,9 @@ from .sql.types import Row
 from .stat_counter import StatCounter
 from .storagelevel import StorageLevel
 
-__all__ = ['RDD', 'Context', 'Broadcast', 'StatCounter', 'CacheManager', 'Row',
-           'TimedCacheManager', 'StorageLevel',
-           'exceptions', 'fileio', 'streaming']
+__all__ = [
+    'RDD', 'Context', 'Broadcast', 'StatCounter', 'CacheManager', 'Row',
+    'TimedCacheManager', 'StorageLevel',
+    'exceptions', 'fileio', 'streaming',
+    'config',
+]

--- a/pysparkling/_config.py
+++ b/pysparkling/_config.py
@@ -1,0 +1,107 @@
+from functools import lru_cache, total_ordering
+import re
+from typing import Union
+
+
+class InvalidVersionFound(Exception):
+    pass
+
+
+@total_ordering
+class Version:
+    __slots__ = ['major', 'minor', 'patch']
+
+    VERSION_RE = re.compile(r'^\s*(?P<major>\d+)\s*(?:\.\s*(?P<minor>\d+)\s*(?:\.\s*(?P<patch>\d+)\s*)?)?$')
+
+    def __init__(
+        self,
+        major: Union[None, str, int] = None,
+        minor: Union[None, str, int] = None,
+        patch: Union[None, str, int] = None
+    ):
+        if isinstance(major, str) and not (minor or patch):  # Allow to pass in a str to directly create the object
+            major = self._parse_version(major)
+
+        if isinstance(major, Version):
+            self.major = major.major
+            self.minor = major.minor
+            self.patch = major.patch
+        else:
+            self.major = int(major or 0)
+            self.minor = int(minor or 0)
+            self.patch = int(patch or 0)
+
+    @staticmethod
+    @lru_cache()  # Put this separately so I can cache the method. Small performance gain likely.
+    def _parse_version(v):
+        if v is None:
+            return v
+
+        if isinstance(v, Version):
+            return v
+
+        match = Version.VERSION_RE.match(v)
+        if not match:
+            raise InvalidVersionFound(f"Cannot parse version '{v}' (expected format: '1.2.3').")
+
+        match = match.groupdict()
+
+        return Version(
+            major=int(match['major'] or 0),
+            minor=int(match['minor'] or 0),
+            patch=int(match['patch'] or 0),
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            other = Version(other)
+
+        return (
+            self.major == other.major
+            and self.minor == other.minor
+            and self.patch == other.patch
+        )
+
+    def __lt__(self, other):
+        if not isinstance(other, Version):
+            other = Version(other)
+
+        return (
+            (self.major, self.minor, self.patch)
+            < (other.major, other.minor, other.patch)
+        )
+
+    def __hash__(self):
+        return hash((self.major, self.minor, self.patch))
+
+    def __repr__(self):
+        return f"Version('{self.major}.{self.minor}.{self.patch}')"
+
+
+class SparkVersion:
+    def __get__(self, instance, owner):
+        if not instance or not hasattr(instance, '_spark_version'):
+            return None
+
+        return getattr(instance, '_spark_version')
+
+    def __set__(self, instance, value):
+        if not instance:
+            return
+
+        if not isinstance(value, Version):
+            value = Version(value)
+
+        setattr(instance, '_spark_version', value)
+
+
+class Configuration:
+    """
+    Configuration object to store dynamic changes in pysparklings behaviour.
+    """
+
+    spark_version = SparkVersion()
+
+
+# Singleton object, only instantiated in this module
+config = Configuration()

--- a/pysparkling/_config.py
+++ b/pysparkling/_config.py
@@ -79,20 +79,26 @@ class Version:
 
 
 class SparkVersion:
+    attr_name = '_spark_version'
+
     def __get__(self, instance, owner):
-        if not instance or not hasattr(instance, '_spark_version'):
+        if not instance or not hasattr(instance, self.attr_name):
             return None
 
-        return getattr(instance, '_spark_version')
+        return getattr(instance, self.attr_name)
 
     def __set__(self, instance, value):
-        if not instance:
+        if value is None:
+            self.__delete__(instance)
             return
 
         if not isinstance(value, Version):
             value = Version(value)
 
-        setattr(instance, '_spark_version', value)
+        setattr(instance, self.attr_name, value)
+
+    def __delete__(self, instance):
+        delattr(instance, self.attr_name)
 
 
 class Configuration:

--- a/pysparkling/tests/test_config.py
+++ b/pysparkling/tests/test_config.py
@@ -1,0 +1,58 @@
+from collections import namedtuple
+
+import pytest
+
+from pysparkling._config import InvalidVersionFound, Version
+
+ConstructorTest = namedtuple('ConstructorTest', 'pass_in major minor patch')
+ComparisonTest = namedtuple('ComparisonTest', 'v1 operation v2 result')
+
+constructor_tests_to_run = [
+    ConstructorTest(pass_in=['1.2.3'], major=1, minor=2, patch=3),
+    ConstructorTest(pass_in=[1, 2, 3], major=1, minor=2, patch=3),
+    ConstructorTest(pass_in=['1', 2, 3], major=1, minor=2, patch=3),
+    ConstructorTest(pass_in=[], major=0, minor=0, patch=0),
+    ConstructorTest(pass_in=[None], major=0, minor=0, patch=0),
+]
+
+comparison_tests_to_run = [
+    ComparisonTest(v1=Version('1'), operation='==', v2=Version('1.0'), result=True),
+    ComparisonTest(v1=Version('1'), operation='<=', v2=Version('1.0.1'), result=True),
+    ComparisonTest(v1=Version('1'), operation='<', v2=Version('1.0.1'), result=True),
+    ComparisonTest(v1=Version('1'), operation='>=', v2=Version('1.0.1'), result=False),
+    ComparisonTest(v1=Version('1'), operation='>', v2=Version('1.0.1'), result=False),
+    ComparisonTest(v1=Version('1'), operation='!=', v2=Version('1.0.1'), result=True),
+    ComparisonTest(v1=Version('1'), operation='!=', v2=Version('1.0.0'), result=False),
+]
+
+
+@pytest.mark.parametrize('pass_in, major, minor, patch', constructor_tests_to_run)
+def test_constructor(pass_in, major, minor, patch):
+    v = Version(*pass_in)
+
+    assert v.major == major
+    assert v.minor == minor
+    assert v.patch == patch
+
+
+def test_wrong_version_constructor():
+    with pytest.raises(InvalidVersionFound):
+        Version('1.0.dev')
+
+
+@pytest.mark.parametrize('v1, operation, v2, result', comparison_tests_to_run)
+def test_comparison(v1, v2, operation, result):
+    if operation == '==':
+        assert (v1 == v2) == result
+    elif operation == '!=':
+        assert (v1 != v2) == result
+    elif operation == '<=':
+        assert (v1 <= v2) == result
+    elif operation == '>=':
+        assert (v1 >= v2) == result
+    elif operation == '<':
+        assert (v1 < v2) == result
+    elif operation == '>':
+        assert (v1 > v2) == result
+    else:
+        raise ValueError("Unknown...")

--- a/pysparkling/tests/test_config.py
+++ b/pysparkling/tests/test_config.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 
-from pysparkling._config import InvalidVersionFound, Version, config
+from pysparkling._config import config, InvalidVersionFound, Version
 
 ConstructorTest = namedtuple('ConstructorTest', 'pass_in major minor patch')
 ComparisonTest = namedtuple('ComparisonTest', 'v1 operation v2 result')

--- a/pysparkling/tests/test_config.py
+++ b/pysparkling/tests/test_config.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 
-from pysparkling._config import InvalidVersionFound, Version
+from pysparkling._config import InvalidVersionFound, Version, config
 
 ConstructorTest = namedtuple('ConstructorTest', 'pass_in major minor patch')
 ComparisonTest = namedtuple('ComparisonTest', 'v1 operation v2 result')
@@ -17,12 +17,15 @@ constructor_tests_to_run = [
 
 comparison_tests_to_run = [
     ComparisonTest(v1=Version('1'), operation='==', v2=Version('1.0'), result=True),
+    ComparisonTest(v1='1', operation='==', v2=Version('1.0'), result=True),
+    ComparisonTest(v1=Version('1'), operation='==', v2='1.0', result=True),
     ComparisonTest(v1=Version('1'), operation='<=', v2=Version('1.0.1'), result=True),
     ComparisonTest(v1=Version('1'), operation='<', v2=Version('1.0.1'), result=True),
     ComparisonTest(v1=Version('1'), operation='>=', v2=Version('1.0.1'), result=False),
     ComparisonTest(v1=Version('1'), operation='>', v2=Version('1.0.1'), result=False),
     ComparisonTest(v1=Version('1'), operation='!=', v2=Version('1.0.1'), result=True),
     ComparisonTest(v1=Version('1'), operation='!=', v2=Version('1.0.0'), result=False),
+    ComparisonTest(v1=None, operation='==', v2=Version('0.0.0'), result=True),
 ]
 
 
@@ -40,6 +43,10 @@ def test_wrong_version_constructor():
         Version('1.0.dev')
 
 
+def test_repr():
+    assert str(Version('1.2.3')) == "Version('1.2.3')"
+
+
 @pytest.mark.parametrize('v1, operation, v2, result', comparison_tests_to_run)
 def test_comparison(v1, v2, operation, result):
     if operation == '==':
@@ -54,5 +61,37 @@ def test_comparison(v1, v2, operation, result):
         assert (v1 < v2) == result
     elif operation == '>':
         assert (v1 > v2) == result
-    else:
-        raise ValueError("Unknown...")
+
+
+def test_set_get_version():
+    assert config.spark_version is None
+
+    config.spark_version = '1.2'
+    assert config.spark_version == Version(1, 2)
+
+    del config.spark_version
+    assert config.spark_version is None
+
+    config.spark_version = '1.2'
+    config.spark_version = None
+    assert config.spark_version is None
+
+    config.spark_version = '1.2'
+    config.spark_version = '1.3'
+    assert config.spark_version == Version(1, 3)
+
+    config.spark_version = '1.2'
+    config.spark_version = Version('1.3')
+    assert config.spark_version == Version(1, 3)
+
+
+def test_in_set():
+    """This tests the hash() method as well."""
+
+    sut = {
+        Version(1, 2, 3),
+        Version('1.2.3'),
+        Version('2.3.1'),
+    }
+
+    assert len(sut) == 2

--- a/pysparkling/tests/test_utils.py
+++ b/pysparkling/tests/test_utils.py
@@ -1,0 +1,93 @@
+import pytest
+
+import pysparkling
+from pysparkling.utils import NotSupportedByThisSparkVersion, since, until
+
+
+@since('2.3.2')
+def since_232():
+    return 'ok'
+
+
+@since('2.4')
+def since_24():
+    return 'ok'
+
+
+@until('2.4')
+def until_24():
+    return 'ok'
+
+
+@until('2.3.2')
+def until_232():
+    return 'ok'
+
+
+@since('2.3')
+@until('2.4')
+def since_23_until_24():
+    return 'ok'
+
+
+@since('2.4')
+class SomeNewFeatureSince:
+    def a(self):
+        return 'ok'
+
+
+@until('2.4')
+class SomeNewFeatureUntil:
+    def a(self):
+        return 'ok'
+
+
+def test_happy_flow():
+    pysparkling.config.spark_version = '2.0'
+    assert until_24() == 'ok'
+
+
+@pytest.mark.parametrize('spark_version_to_set, method, should_raise', [
+    ('2.3.1', since_232, True),
+    ('2.3.2', since_232, False),
+    ('2.3.3', since_232, False),
+
+    ('2.3.3', since_24, True),
+    ('2.4', since_24, False),
+
+    ('2.3.2', SomeNewFeatureSince().a, True),
+    ('2.4.1', SomeNewFeatureSince().a, False),
+
+    # The following I only need to check once (not in since/until twice).
+    ('2.2', since_23_until_24, True),
+    ('2.3', since_23_until_24, False),
+    ('2.3.1', since_23_until_24, False),
+    ('2.4', since_23_until_24, True),
+])
+def test_since(spark_version_to_set, method, should_raise):
+    pysparkling.config.spark_version = spark_version_to_set
+    if should_raise:
+        with pytest.raises(NotSupportedByThisSparkVersion):
+            method()
+    else:
+        assert method() == 'ok'
+
+
+@pytest.mark.parametrize('spark_version_to_set, method, should_raise', [
+    ('2.3.1', until_232, False),
+    ('2.3.2', until_232, True),
+    ('2.3.3', until_232, True),
+
+    ('2.3.3', until_24, False),
+    ('2.4', until_24, True),
+
+    ('2.3.2', SomeNewFeatureUntil().a, False),
+    ('2.4.1', SomeNewFeatureUntil().a, True),
+])
+def test_until(spark_version_to_set, method, should_raise):
+    pysparkling.config.spark_version = spark_version_to_set
+    if should_raise:
+        with pytest.raises(NotSupportedByThisSparkVersion):
+            method()
+    else:
+        assert method() == 'ok'

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ exclude = venv*,logo,docs,build
 max-line-length = 119
 
 [tool:pytest]
-addopts = --doctest-modules --cov=pysparkling --cov-report=html --cov-branch
+addopts = --doctest-modules --cov=pysparkling --cov-report html --cov-report xml:reports/coverage.xml --cov-branch
 testpaths = pysparkling
 doctest_optionflags = ALLOW_UNICODE NORMALIZE_WHITESPACE
 


### PR DESCRIPTION
This is very useful when going to implement methods in pysparkling.

Example: "weekday" exists since 2.4.0.

This way you can decorate the method/class with @since('2.4.0').

In your pysparkling program you can say `pysparkling.config.spark_version = 2.3.2`. And if you would be using SOMEWHERE "weekday" in the code, it would fire the `NotSupportedByThisSparkVersion` exception. Thus correctly failing your pysparkling program.

FYI: function reference: http://spark.apache.org/docs/latest/api/sql/index.html

---

I also added `@until` in there. I didn't knew if this is yet needed, but it was a small effort to add it.

Furthermore @tools4origins mentioned that some behaviour changed between pyspark 2 & 3 (int being `IntegerType` or `LongType`). These implementations could help with that...

But I'm not very clear yet what version to target with `@since`. Should it target the underlying spark version, or the pyspark library of that specific version?
